### PR TITLE
Update mocha and remove unnecessary done callback in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "4"
+  - "5"
+  - "6"
+  - "stable"

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var mkdirp = require('mkdirp');
 var CachingWriter = require('broccoli-caching-writer');
 var helpers = require('broccoli-kitchen-sink-helpers');
 var svgstore = require('svgstore');
-// var svgToSymbol = require('./utils/svg-to-symbol');
 
 var defaultSettings = {
   outputFile: '/images.svg',

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "broccoli": "0.16.9",
     "chai": "3.5.0",
+    "cheerio": "^0.22.0",
     "mocha": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "broccoli-caching-writer": "3.0.0",
     "broccoli-kitchen-sink-helpers": "0.3.1",
-    "cheerio": "^0.20.0",
     "mkdirp": "^0.5.1",
     "object-assign": "4.1.0",
     "svgstore": "1.1.0"
@@ -34,6 +33,6 @@
   "devDependencies": {
     "broccoli": "0.16.9",
     "chai": "3.5.0",
-    "mocha": "2.5.3"
+    "mocha": "^3.0.2"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,12 +23,14 @@ ID_MANIFEST[SOURCE_DIR_GROUP_1] = ['icon-circles', 'icon-triangle', 'icon-star',
 ID_MANIFEST[SOURCE_DIR_GROUP_2] = ['icon-square', 'icon-smiley', 'icon-movie-ticket'];
 ID_MANIFEST[SOURCE_DIR_SVGSTORE_OPTS] = ['svgstore-opts'];
 
-function makeBuilderFromInputNodes(inputNodes, options = {}) {
+function makeBuilderFromInputNodes(inputNodes, options) {
+  var options = options || {};
   var svgProcessor = new SvgProcessor(inputNodes, {
     outputFile: options.outputFile || OUTPUT_FILE,
     annotation: options.annotation || 'SVGStore Processor -- Tests',
     svgstoreOpts: options.svgstoreOpts || {} 
   });
+  
   return new broccoli.Builder(svgProcessor); 
 }
 
@@ -37,9 +39,7 @@ function loadSVG(filePath) {
   return cheerio.load(fileContent, { xmlMode: true });
 }
 
-function testForSymbols($loadedSVG, expectedSymbolIds, opts = {}) {
-  // var fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
-  // var $ = cheerio.load(fileContent, { xmlMode: true });
+function testForSymbols($loadedSVG, expectedSymbolIds) {
   
   // test proper structure
   var $svg = $loadedSVG('svg');
@@ -55,9 +55,8 @@ function testForSymbols($loadedSVG, expectedSymbolIds, opts = {}) {
 
   expect(symbols.length).to.equal(expectedSymbolIds.length);
 
-  var $symbol;
   expectedSymbolIds.forEach(function (id, idx) {
-    $symbol = $loadedSVG('svg #' + id).first();
+    var $symbol = $loadedSVG('svg #' + id).first();
     expect($symbol[0].tagName).to.equal('symbol');
     expect($symbol.attr('id')).to.equal(id);
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,7 +113,7 @@ describe('SVGProcessor', function () {
 
   describe('build', function() {
 
-    it('writes all SVGs in a single directory to the target outputFile', function(done) {      
+    it('writes all SVGs in a single directory to the target outputFile', function() {      
       var inputNodes = [SOURCE_DIR_GROUP_1];
       builder = makeBuilderFromInputNodes(inputNodes);
 
@@ -121,11 +121,10 @@ describe('SVGProcessor', function () {
         var outputDestination = path.join(results.directory, path.normalize(OUTPUT_FILE));
         
         testForSymbols(loadSVG(outputDestination), ID_MANIFEST[SOURCE_DIR_GROUP_1]);
-        done();
       });    
     });
 
-    it('writes all SVGs from a list of directories to the target outputFile', function(done) {
+    it('writes all SVGs from a list of directories to the target outputFile', function() {
       var inputNodes = [SOURCE_DIR_GROUP_1, SOURCE_DIR_GROUP_2];
       builder = makeBuilderFromInputNodes(inputNodes);
 
@@ -134,12 +133,11 @@ describe('SVGProcessor', function () {
         var symbolIds = ID_MANIFEST[SOURCE_DIR_GROUP_1].concat(ID_MANIFEST[SOURCE_DIR_GROUP_2]);  
 
         testForSymbols(loadSVG(outputDestination), symbolIds);
-        done();
       });      
     });
 
     // TODO: Implement test
-    it('passes options to SVGStore', function(done) {
+    it('passes options to SVGStore', function() {
       var inputNode = SOURCE_DIR_SVGSTORE_OPTS;
       var CUSTOM_ATTR_VALUES = {
         'x-custom-attr': 'foo'
@@ -157,7 +155,6 @@ describe('SVGProcessor', function () {
         testForSymbols($, symbolId);
 
         expect($('symbol').attr('x-custom-attr')).to.equal(CUSTOM_ATTR_VALUES['x-custom-attr']);
-        done();
       });
     });
   });


### PR DESCRIPTION
Replaces #14. Upgrading to mocha 3 exposed the unnecessary `done` callback in a few tests. I've also removed `cheerio` as a dependency, since it's no longer used after #10.
