### PR TITLE
Support custom ids and per file opts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SVGs with [`svgstore`](https://github.com/svgstore/svgstore)
 ## Installation
 
 
-```
+```shell
 npm install --save broccoli-svgstore 
 ```
 
@@ -41,9 +41,9 @@ Within your markup, you should now be able to "use" each symbol inside of other 
 - `inputNode|inputNodes` {inputNode or Array of inputNodes}: A standalone [Broccoli Node](https://github.com/broccolijs/broccoli/blob/master/docs/node-api.md), or a list of them. 
   The root of each node's source directory will form the starting point for a recursive search of `.svg` files.
 
-- `options`: {Object}: [Options for `broccoli-svgstore`](#broccoli-svgstore-options) 
+- `options` {Object}: [Options for `broccoli-svgstore`](#options)
 
-### <a name="broccoli-svgstore-options"></a>Options
+### Options
 - <a name="option-outputFile"></a>`outputFile` {string}: The name of the file -- including any directory 
   path -- [to which output will be written](https://github.com/broccolijs/broccoli-plugin#pluginprototypebuild)
   (starting from the root directory of your build destination).
@@ -62,4 +62,22 @@ Within your markup, you should now be able to "use" each symbol inside of other 
 
   Required: `false`  
   Default: `{}`
+
+- `fileSettings` {Object}: a hash of per-file settings. 
+That is, each root key should correspond to a file name of an SVG that 
+will be found in this node. It's value should then be an Object with any of the following settings:
+  + `id` {string}: A custom id to be used for this SVG's final `<symbol>`.
+  + `svgstoreOpts` {Object}: same as `options.svgstoreOpts`, but scoped to the file
+
+  Example usage:
+
+  ```javascript
+    var outputNode = svgstore(inputNodes, {
+      outputFile: "/assets/icons.svg",
+      fileSettings: {
+        twitter: { id: 'tweet' },
+        menu: { id: 'hamburger', svgstoreOpts: { customSymbolAttrs: ['preserveAspectRatio'] } }
+      }
+    });
+  ```
 

--- a/index.js
+++ b/index.js
@@ -45,33 +45,35 @@ SvgProcessor.prototype = Object.create(CachingWriter.prototype);
 SvgProcessor.prototype.constructor = SvgProcessor;
 SvgProcessor.prototype.description = 'svgstore';
 
-SvgProcessor.prototype.build = function () {
+/**
+ * Overrides broccoli-plugin's `build' function.
+ * @see: https://github.com/broccolijs/broccoli-plugin#pluginprototypebuild
+ */
+SvgProcessor.prototype.build = function() {
 
   var svgOutput = svgstore(this._options.svgstoreOpts);
+  var fileSettings = this._options.fileSettings || {};
 
   try {
-    var srcDir;
-    var inputFiles;
-    var inputFileName;
-    var inputFilePath;
-    var stat;
-    var fileContents;
-    var svgId;
-    
+    // iterate through `inputPaths` of our `inputNodes` (`inputPaths` is an array of 
+    // paths on disk corresponding to each node in `inputNodes`)
     for (var i = 0, l = this.inputPaths.length; i < l; i++) {
-      srcDir = this.inputPaths[i];
-      inputFiles = helpers.multiGlob(["**/*.svg"], { cwd: srcDir });
+      var srcDir = this.inputPaths[i];
+      var inputFiles = helpers.multiGlob(["**/*.svg"], { cwd: srcDir });
 
       for (var j = 0, ll = inputFiles.length; j < ll; j++) {
-        inputFileName = inputFiles[j];
-        inputFilePath = path.join(srcDir, inputFileName);
-        stat = fs.statSync(inputFilePath);
+        var inputFileName = inputFiles[j];
+        var inputFilePath = path.join(srcDir, inputFileName);
+        var stat = fs.statSync(inputFilePath);
 
         if (stat && stat.isFile()) {
-          fileContents = fs.readFileSync(inputFilePath, { encoding: 'utf8' });
-          svgId = inputFileName.replace(/\.[^\.]+$/, '');
+          var fileNameWithoutExtension = inputFileName.replace(/\.[^\.]+$/, '');  
+          var fileContents = fs.readFileSync(inputFilePath, { encoding: 'utf8' });
+          var inputFileSettings = fileSettings[fileNameWithoutExtension] || {};
+          var svgId = inputFileSettings.id || fileNameWithoutExtension;  
+          var fileSVGStoreOpts = inputFileSettings.svgstoreOpts || {};
           
-          svgOutput.add(svgId, fileContents);
+          svgOutput.add(svgId, fileContents, fileSVGStoreOpts);
         }
       }
     }


### PR DESCRIPTION
This PR introduces the option to control the options passed to `svgstore` on a per-file basis. [Full documentation has been added to the README](https://github.com/svgstore/broccoli-svgstore/tree/support-custom-ids-and-per-file-opts#options), and it should also close #3. 
