### PR TITLE
assertAbsolutePaths doesn't handle windows paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var mkdirp = require('mkdirp');
 var CachingWriter = require('broccoli-caching-writer');
 var helpers = require('broccoli-kitchen-sink-helpers');
 var svgstore = require('svgstore');
+var assert = require('assert');
 
 var defaultSettings = {
   outputFile: '/images.svg',
@@ -83,7 +84,7 @@ SvgProcessor.prototype.build = function() {
     }
   }
 
-  helpers.assertAbsolutePaths([this.outputPath]); // ❓❓ QUESTION: Necessary?
+  assert(path.isAbsolute(this.outputPath), 'output path must be absolute'); // ❓❓ QUESTION: Necessary?
 
   var outputDestination = path.join(this.outputPath, this._options.outputFile);
 


### PR DESCRIPTION
We've been trying to get our app building on windows recently, and the build fails when it hits this assertion.  The path being tested was a valid absolute path on windows, but the `assertAbsolutePaths` doesn't understand windows paths.

I left the comment in place.  Its not clear to me that the assertion is needed at all.  Simply removing the test would also work for me.