### PR TITLE
Move svgstore to devDependencies and peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SVGs with [`svgstore`](https://github.com/svgstore/svgstore)_
 
 
 ```shell
-npm install --save broccoli-svgstore
+npm install --save svgstore broccoli-svgstore
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -30,13 +30,16 @@
     "broccoli-caching-writer": "3.0.0",
     "broccoli-kitchen-sink-helpers": "0.3.1",
     "mkdirp": "^0.5.1",
-    "object-assign": "4.1.0",
-    "svgstore": "^2.0.2"
+    "object-assign": "4.1.0"
+  },
+  "peerDependencies": {
+    "svgstore": "*"
   },
   "devDependencies": {
     "broccoli": "0.16.9",
     "chai": "4.0.1",
     "cheerio": "^0.22.0",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "svgstore": "^2.0.2"
   }
 }


### PR DESCRIPTION
Move svgstore to devDependencies and peerDependencies for the sake of having the flexibility to change the used svgstore version outside of the plugin.

The thing is that we have to use our customized `svgstore` since we're experimenting a lot with the icons automatically exported from Sketch and keep those changes in a feature branch, which is not fully ready for a PR. So, it'd be great to have a possibility to pass our own svgstore to the broccoli plugin, and I was about to propose an option for the plugin, but having a peer dependency seems to me a more convenient way to have it done.